### PR TITLE
Allow real partial updates on the UKF filter.

### DIFF
--- a/src/mtk_ukf/MeasurementModels.hpp
+++ b/src/mtk_ukf/MeasurementModels.hpp
@@ -1,18 +1,19 @@
 #ifndef _MEASUREMENT_MODELS_HPP_
 #define _MEASUREMENT_MODELS_HPP_
 
-#include "PoseWithVelocity.hpp"
+#include <Eigen/Core>
 
 namespace pose_estimation
 {
-    
+
 /** Measurement model for the 12D robot state (pose and velocity)
+ *  The mask defines which subset is returned.
  */
 template <typename PoseWithVelocityType>
-PoseWithVelocityType
-measurementModel (const PoseWithVelocityType &state)
+Eigen::Matrix<typename PoseWithVelocityType::scalar, -1, 1>
+measurementModel (const PoseWithVelocityType &state, const Eigen::Matrix<unsigned, PoseWithVelocityType::DOF, 1>& mask)
 {
-    return state;
+    return state.getSubStateVector(mask);
 }
     
 }


### PR DESCRIPTION
Improves and fixes the integration of partial measurement updates using the MTK UKF.
This depends on rock-slam/slam-mtk#1 which makes the implementation capable of handling dynamic sized measurements.
