### PR TITLE
Use acceleration in prediction step

### DIFF
--- a/src/Measurement.hpp
+++ b/src/Measurement.hpp
@@ -2,6 +2,7 @@
 #define _POSE_ESTIMATION_MEASUREMENT_HPP
 
 #include <base/samples/RigidBodyState.hpp>
+#include <base/samples/RigidBodyAcceleration.hpp>
 #include <Eigen/Core>
 
 namespace pose_estimation
@@ -20,49 +21,64 @@ namespace pose_estimation
     BodyStateMemberVz,
     BodyStateMemberVroll,
     BodyStateMemberVpitch,
-    BodyStateMemberVyaw
+    BodyStateMemberVyaw,
+    BodyStateMemberAx,
+    BodyStateMemberAy,
+    BodyStateMemberAz,
   };
 
   const int BODY_STATE_SIZE = 12;
+  const int MEASUREMENT_SIZE = BODY_STATE_SIZE + 3;
   
   typedef Eigen::Matrix<double, BODY_STATE_SIZE, BODY_STATE_SIZE> Covariance;
 
 struct Measurement
 {
-    typedef Eigen::Matrix<unsigned, BODY_STATE_SIZE, 1> MemberMask;
+    typedef Eigen::Matrix<unsigned, MEASUREMENT_SIZE, 1> MemberMask;
     
+    base::Time time;
     base::samples::RigidBodyState body_state;
+    base::samples::RigidBodyAcceleration acceleration;
     MemberMask member_mask;
+
+    Measurement() : member_mask(MemberMask::Zero()) {}
     
-    bool operator()(const Measurement &a, const Measurement &b)
+    bool operator()(const Measurement &a, const Measurement &b) const
     {
-	return a.body_state.time > b.body_state.time;
+	return a.time > b.time;
     }
     
-    bool hasPositionMeasurement()
+    bool hasPositionMeasurement() const
     {
         if(member_mask[BodyStateMemberX] || member_mask[BodyStateMemberY] || member_mask[BodyStateMemberZ])
             return true;
         return false;
     }
     
-    bool hasOrientationMeasurement()
+    bool hasOrientationMeasurement() const
     {
         if(member_mask[BodyStateMemberRoll] || member_mask[BodyStateMemberPitch] || member_mask[BodyStateMemberYaw])
             return true;
         return false;
     }
     
-    bool hasVelocityMeasurement()
+    bool hasVelocityMeasurement() const
     {
         if(member_mask[BodyStateMemberVx] || member_mask[BodyStateMemberVy] || member_mask[BodyStateMemberVz])
             return true;
         return false;
     }
     
-    bool hasAngularVelocityMeasurement()
+    bool hasAngularVelocityMeasurement() const
     {
         if(member_mask[BodyStateMemberVroll] || member_mask[BodyStateMemberVpitch] || member_mask[BodyStateMemberVyaw])
+            return true;
+        return false;
+    }
+
+    bool hasAccelerationMeasurement() const
+    {
+        if(member_mask[BodyStateMemberAx] || member_mask[BodyStateMemberAy] || member_mask[BodyStateMemberAz])
             return true;
         return false;
     }

--- a/src/PoseEKF.cpp
+++ b/src/PoseEKF.cpp
@@ -31,10 +31,10 @@ void PoseEKF::correctionStep(const Measurement& measurement)
     dirty = true;
     
     RobotLocalization::Measurement m;
-    m.time_ = measurement.body_state.time.toSeconds();
+    m.time_ = measurement.time.toSeconds();
     rigidBodyStateToMarix(measurement.body_state, m.measurement_, m.covariance_);
     m.updateVector_.resize(BODY_STATE_SIZE);
-    Eigen::Map< Eigen::Matrix<int, BODY_STATE_SIZE, 1> >(m.updateVector_.data()) = measurement.member_mask.cast<int>();
+    Eigen::Map< Eigen::Matrix<int, BODY_STATE_SIZE, 1> >(m.updateVector_.data()) = measurement.member_mask.cast<int>().block(0,0,BODY_STATE_SIZE,1);
     Ekf::correct(m);
 }
 

--- a/src/PoseEstimator.hpp
+++ b/src/PoseEstimator.hpp
@@ -22,6 +22,10 @@ public:
     
     bool enqueueMeasurement(const base::samples::RigidBodyState& body_state,
 			    const Measurement::MemberMask& member_mask);
+    bool enqueueMeasurement(const base::Time time,
+                            const base::samples::RigidBodyState& body_state,
+                            const base::samples::RigidBodyAcceleration& acceleration,
+                            const Measurement::MemberMask& member_mask);
     bool enqueueMeasurement(const Measurement& measurement);
     
     void integrateMeasurements();

--- a/src/PoseUKF.cpp
+++ b/src/PoseUKF.cpp
@@ -63,7 +63,7 @@ void PoseUKF::correctionStep(const Measurement& measurement)
     rigidBodyStateToUKFState(measurement.body_state, state, cov);
     
     // check state for NaN values
-    Measurement::MemberMask mask = measurement.member_mask;
+    Eigen::Matrix<unsigned, BODY_STATE_SIZE, 1> mask = measurement.member_mask.block(0,0,BODY_STATE_SIZE,1);
     Eigen::Matrix<WPoseState::scalar_type, WPoseState::DOF, 1> state_vector = state.getStateVector();
     for(unsigned i = 0; i < WPoseState::DOF; i++)
     {

--- a/src/PoseUKF.hpp
+++ b/src/PoseUKF.hpp
@@ -36,6 +36,7 @@ protected:
     boost::shared_ptr<MTK_UKF> ukf;
     bool dirty;
     base::samples::RigidBodyState body_state;
+    base::samples::RigidBodyAcceleration last_acceleration_sample;
     Covariance process_noise_cov;
 };
 

--- a/src/mtk_ukf/PoseWithVelocity.hpp
+++ b/src/mtk_ukf/PoseWithVelocity.hpp
@@ -74,6 +74,13 @@ public:
 	position.boxplus(orientation * velocity, delta_time);
 	orientation.boxplus(angular_velocity, delta_time);
     }
+
+    void applyVelocity(const Eigen::Vector3d& acc, double delta_time)
+    {
+        velocity.boxplus(acc, delta_time);
+        position.boxplus(orientation * velocity, delta_time);
+        orientation.boxplus(angular_velocity, delta_time);
+    }
     
     Eigen::Matrix<scalar, DOF, 1> getStateVector() const
     {

--- a/src/mtk_ukf/ProcessModels.hpp
+++ b/src/mtk_ukf/ProcessModels.hpp
@@ -16,6 +16,17 @@ PoseWithVelocityType processModel (const PoseWithVelocityType &state, double del
     new_state.applyVelocity(delta_time);
     return new_state;
 }
+
+/** Process model with acceleration for the 12D robot state.
+ * Applies the current velocity and acceleration to update the robot pose.
+ */
+template <typename PoseWithVelocityType>
+PoseWithVelocityType processModelWithAcceleration (const PoseWithVelocityType &state, const Eigen::Vector3d& acc, double delta_time)
+{
+    PoseWithVelocityType new_state(state);
+    new_state.applyVelocity(acc, delta_time);
+    return new_state;
+}
     
 }
 


### PR DESCRIPTION
This extends the measurement by accelerations. The state of the filter stays unchanged.
It also integrates the use of the accelerations in the prediction step of the UKF filter, if no acceleration measurements are available it applies only the velocity as before.
