### PR TITLE
added mtk as dependency, since it exports a pkg config now

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,6 @@ set (POSE_ESTIMATION_SOURCES
 rock_library(pose_estimation
     SOURCES ${POSE_ESTIMATION_SOURCES}
     HEADERS ${POSE_ESTIMATION_HEADERS}
-    DEPS_PKGCONFIG eigen3 base-types base-lib
+    DEPS_PKGCONFIG eigen3 base-types base-lib mtk
     DEPS_CMAKE LAPACK)
     


### PR DESCRIPTION
This PR depends on rock-slam/slam-mtk#5
